### PR TITLE
Fixed Bug with writing Floppy Images back to Disk.

### DIFF
--- a/storage_disk.go
+++ b/storage_disk.go
@@ -50,7 +50,7 @@ func (DS *DiskStorage) Read(Item string, offset int, data []byte) {
 }
 
 func (DS *DiskStorage) Write(Item string, offset int, data []byte) {
-	file, err := os.OpenFile(filepath.Join(DS.basepath, Item), os.O_CREATE, 0777)
+	file, err := os.OpenFile(filepath.Join(DS.basepath, Item), os.O_CREATE | os.O_WRONLY, 0777)
 	if err != nil {
 		return
 	}

--- a/storage_flip.go
+++ b/storage_flip.go
@@ -19,5 +19,5 @@ func (FS *FlipStorage) Write(Item string, offset int, data []byte) {
 	for l1 := 0; l1 < len(data)/2; l1++ {
 		data[l1*2], data[l1*2+1] = data[l1*2+1], data[l1*2]
 	}
-	FS.Write(Item, offset, data)
+	FS.Storage.Write(Item, offset, data)
 }


### PR DESCRIPTION
I was toying around with the emulator and thought of adding the feature to save written floppies into it.
While browsing the source code it turned out it was already implemented. It just Doesn't work.

The First bug was in storage_flip.go, where it was recursively calling its own Write method.
Then in storage_disk.go on my 64bit arch linux I got a bad FileDescriptor Error inside file.Write().
Apparently a additional flag is OpenFile was needed.

Now saving floppys is working and I can experiment with File Systems ^^